### PR TITLE
mixpanel-browser@2.40.0: Add `persistent` option to `register()`

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -163,10 +163,8 @@ export interface Mixpanel {
     opt_in_tracking(options?: Partial<InTrackingOptions>): void;
     opt_out_tracking(options?: Partial<OutTrackingOptions>): void;
     push(item: PushItem): void;
-    register(props: Dict, days?: number): void;
-    register(props: Dict, options?: RegisterOptions): void;
-    register_once(props: Dict, default_value?: any, days?: number): void;
-    register_once(props: Dict, default_value?: any, options?: RegisterOptions): void;
+    register(props: Dict, daysOrOptions?: number | RegisterOptions): void;
+    register_once(props: Dict, default_value?: any, daysOrOptions?: number | RegisterOptions): void;
     remove_group(group_key: string, group_ids: string | string[] | number | number[], callback?: Callback): void;
     reset(): void;
     set_config(config: Partial<Config>): void;

--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mixpanel-browser 2.38
+// Type definitions for mixpanel-browser 2.40
 // Project: https://github.com/mixpanel/mixpanel-js
 // Definitions by: Carlos López <https://github.com/karlos1337>
 //                 Ricardo Rodrigues <https://github.com/RicardoRodrigues>
@@ -47,6 +47,10 @@ export interface InTrackingOptions extends ClearOptOutInOutOptions {
 
 export interface OutTrackingOptions extends ClearOptOutInOutOptions {
     delete_user: boolean;
+}
+
+export interface RegisterOptions {
+    persistent: boolean;
 }
 
 export interface Config {
@@ -160,7 +164,9 @@ export interface Mixpanel {
     opt_out_tracking(options?: Partial<OutTrackingOptions>): void;
     push(item: PushItem): void;
     register(props: Dict, days?: number): void;
+    register(props: Dict, options?: RegisterOptions): void;
     register_once(props: Dict, default_value?: any, days?: number): void;
+    register_once(props: Dict, default_value?: any, options?: RegisterOptions): void;
     remove_group(group_key: string, group_ids: string | string[] | number | number[], callback?: Callback): void;
     reset(): void;
     set_config(config: Partial<Config>): void;
@@ -175,7 +181,7 @@ export interface Mixpanel {
     track_forms(query: Query, event_name: string, properties?: Dict | (() => void)): void;
     track_links(query: Query, event_name: string, properties?: Dict | (() => void)): void;
     track_with_groups(event_name: string, properties: Dict, groups: Dict, callback?: Callback): void;
-    unregister(property: string): void;
+    unregister(property: string, options?: RegisterOptions): void;
     people: People;
 }
 

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -34,9 +34,19 @@ mixpanel.register({
     Email: 'jdoe@example.com',
     'Account Type': 'Free',
 });
+mixpanel.register({ Gender: 'Female' }, 1);
+mixpanel.register({ Gender: 'Female' }, { persistent: true });
 mixpanel.register_once({
     'First Login Date': new Date().toISOString(),
 });
+mixpanel.register_once({
+    'First Login Date': new Date().toISOString(),
+}, 1);
+mixpanel.register_once({
+    'First Login Date': new Date().toISOString(),
+}, { persistent: true });
+mixpanel.unregister('Gender');
+mixpanel.unregister('Gender', { persistent: true });
 mixpanel.init('YOUR PROJECT TOKEN', {
     loaded: mixpanel => {
         const distinct_id = mixpanel.get_distinct_id();


### PR DESCRIPTION
mixpanel-browser@2.40.0: [Add `persistent` option to `register()`](https://github.com/mixpanel/mixpanel-js/commit/f9314b63d0c6de26b6d515a756eafc08c95c9975)

**Changelog:**
**2.40.0** (2 Dec 2020)
- Add `persistent` option to `register()`, to support setting superproperties only for the current pageload
- Add before-send `hooks` for transforming/enriching data before it goes over the network
- Add `batch_autostart` config option and `start_batch_senders()` method, to allow extra control over when batches start sending over the network
- Fix request-batching when `sendBeacon` is specified as default API transport
- Increase batch_requests default rollout to 60% of projects

**⚠️ Please note:** I haven't included the changes related to `batch_autostart` and `start_batch_senders` since they weren't included in the [API reference](https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md).


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mixpanel/mixpanel-js/commit/f9314b63d0c6de26b6d515a756eafc08c95c9975
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

