### PR TITLE
mixpanel-browser@2.43.0

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mixpanel-browser 2.40
+// Type definitions for mixpanel-browser 2.43
 // Project: https://github.com/mixpanel/mixpanel-js
 // Definitions by: Carlos López <https://github.com/karlos1337>
 //                 Ricardo Rodrigues <https://github.com/RicardoRodrigues>
@@ -56,6 +56,7 @@ export interface RegisterOptions {
 export interface Config {
     api_host: string;
     api_method: string;
+    api_payload_format: "base64" | "json";
     api_transport: string;
     app_host: string;
     autotrack: boolean;

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -354,3 +354,13 @@ mixpanel.track_with_groups('event', { name: 'Name' }, { group: ['value'] }, resp
     } else if (response.status === 0 && response.error.includes('bad')) {
     }
 });
+mixpanel.init('YOUR PROJECT TOKEN', {
+    api_payload_format: 'json',
+});
+mixpanel.init('YOUR PROJECT TOKEN', {
+    api_payload_format: 'base64',
+});
+mixpanel.init('YOUR PROJECT TOKEN', {
+    // $ExpectError
+    api_payload_format: 'bytes',
+});


### PR DESCRIPTION
mixpanel-browser@2.43.0: [Support plain JSON tracking payloads](https://github.com/mixpanel/mixpanel-js/commit/299850c74131923454b79b8b170353c197a8b0c8)

**Changelog:**
**2.43.0** (5 Jan 2022)
- Support plain JSON tracking payloads (no base64-encoding) and use as default when sendinig to *.mixpanel.com API hosts


Checklist
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mixpanel/mixpanel-js/commit/299850c74131923454b79b8b170353c197a8b0c8
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

